### PR TITLE
Fix documentation errors: Docker tag and script usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements.txt file into the container at /app
+COPY requirements.txt /app/
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -39,16 +39,18 @@ docker build -t forbidden-buster-image .
 ```
 
 #### Running the Docker Container
-Next, run the Docker container. You need to pass a folder containing the files to analyze as a volume:
+Next, run the Docker container. Pass the `forbidden_buster.py` script to the container.
 
 ```bash
-docker run --rm -it -v /path/to/your/folder:/app forbidden-buster-image /bin/bash
+docker run --rm -it -v /path/to/forbidden_buster.py:/app/forbidden_buster.py forbidden-buster-image /bin/bash
 ```
 
-Inside the container, navigate to the /app directory and run your analysis using Forbidden-Buster command as normal.
-
 > [!NOTE]  
-> Make sure to replace /path/to/your/folder with the actual path to the folder containing the files you want to analyze. This command mounts your local folder into the /app directory inside the container, allowing you to run the Forbidden-Buster command on your files.
+> Make sure to replace `/path/to/forbidden_buster.py` with the actual path to your `forbidden_buster.py` file. This command mounts your local file into the `/app` directory inside the container, allowing you to run the `forbidden_buster.py` script directly.
+
+
+
+Inside the container, navigate to the `/app` directory and run the script as normal.
 
 ## Arguments
 Forbidden Buster accepts the following arguments:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ python3 forbidden_buster.py -u http://example.com
 ```
 
 ### Using Docker
-You can also use Docker to run Forbidden-Buster. This approach ensures that you have a consistent environment without needing to install Go on your host machine.
+You can also use Docker to run Forbidden-Buster. This approach ensures that you have a consistent environment without needing to install Python on your host machine.
 
 #### Building the Docker Image
 First, build the Docker image:

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ You can also use Docker to run Forbidden-Buster. This approach ensures that you 
 First, build the Docker image:
 
 ```bash
-docker build -t Forbidden-Buster-image .
+docker build -t forbidden-buster-image .
 ```
 
 #### Running the Docker Container
 Next, run the Docker container. You need to pass a folder containing the files to analyze as a volume:
 
 ```bash
-docker run --rm -it -v /path/to/your/folder:/app Forbidden-Buster-image /bin/bash
+docker run --rm -it -v /path/to/your/folder:/app forbidden-buster-image /bin/bash
 ```
 
 Inside the container, navigate to the /app directory and run your analysis using Forbidden-Buster command as normal.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ Run the script
 python3 forbidden_buster.py -u http://example.com
 ```
 
+### Using Docker
+You can also use Docker to run Forbidden-Buster. This approach ensures that you have a consistent environment without needing to install Go on your host machine.
+
+#### Building the Docker Image
+First, build the Docker image:
+
+```bash
+docker build -t Forbidden-Buster-image .
+```
+
+#### Running the Docker Container
+Next, run the Docker container. You need to pass a folder containing the files to analyze as a volume:
+
+```bash
+docker run --rm -it -v /path/to/your/folder:/app Forbidden-Buster-image /bin/bash
+```
+
+Inside the container, navigate to the /app directory and run your analysis using Forbidden-Buster command as normal.
+
+> [!NOTE]  
+> Make sure to replace /path/to/your/folder with the actual path to the folder containing the files you want to analyze. This command mounts your local folder into the /app directory inside the container, allowing you to run the Forbidden-Buster command on your files.
+
 ## Arguments
 Forbidden Buster accepts the following arguments:
 


### PR DESCRIPTION
This pull request addresses two documentation issues:

1. **Docker name tag correction:** Fixed the incorrect Docker name tag in the documentation by changing it from uppercase to lowercase to comply with Docker's naming conventions.

2. **Simplified Docker run command:** Updated the instructions for running the Docker container to clarify that only the `forbidden_buster.py` script needs to be passed to the container, not the entire folder.

These changes ensure the documentation is accurate and easier to follow.